### PR TITLE
Implement tab autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
-# HomeTerm
+# (Reiden's) HomeTerm
+
+> Welcome to reiden's fork of the original HomeTerm!
+>
+> This repo is a fork of Jared's HomeTerm project, but with certain changes deemed necessary for regular usage.
+>
+> Key changes:
+> - Added tab autocomplete, **super** necessary for any terminal user.
+> - Replaced `open <path>` with `./<path>` to be more aligned with conventional terminal usage. After all, each link behaves a binary that opens a new page.
+>
+> Enjoy!
+
 
 A homepage disguised as a toy terminal!
 
@@ -19,7 +30,7 @@ Here are the currently available commands that can be run on the terminal.
 | `ls`     | `ls [<path to dir>]`              | List children of current working directory or given directory.                                                                                                                       |
 | `tree`   | `tree [<path to dir>]`            | Lists all children of current working directory or given directory in tree format                                                                                                    |
 | `cd`     | `cd [<path>]`                     | Move into given directory. If no path given move to root.                                                                                                                            |
-| `open`   | `open <path to link>`             | Open a link in a new tab.                                                                                                                                                            |
+| `open`   | `./<path to link>`                | Open a link in a new tab.                                                                                                                                                            |
 | `touch`  | `touch <path to link> <url>`      | Create a new link                                                                                                                                                                    |
 | `mkdir`  | `mkdir <path to dir>`             | Create a new directory                                                                                                                                                               |
 | `rm`     | `rm <path to link>`               | Delete link                                                                                                                                                                          |

--- a/src/cli.js
+++ b/src/cli.js
@@ -104,6 +104,10 @@ function handleKeyPresses(e) {
         return pushCommand(commandHistory[commandHistoryCursor]);
       }
       break;
+    case "Tab":
+      e.preventDefault();
+      const curr_input = document.getElementById("prompt-input");
+      return completeToken(curr_input.value);
     default:
       break;
   }

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,7 +2,8 @@
 const COMMANDS = {
   ls: { func: joinWriter(list, treeWriter), help: "usage: ls [<path to dir>]" },
   cd: { func: joinWriter(cd, textWriter), help: "usage: cd [<path>]" },
-  open: { func: joinWriter(openLink, textWriter), help: "usage: open <path>" },
+  './': { func: joinWriter(openLink, textWriter), help: "usage: ./<path>" },
+  open: { func: joinWriter(openRedirect, textWriter), help: "usage: ./<path>" },
   touch: {
     func: joinWriter(touch, textWriter),
     help: "usage: touch <path to link> <url>",

--- a/src/cli.js
+++ b/src/cli.js
@@ -107,6 +107,7 @@ function handleKeyPresses(e) {
     case "Tab":
       e.preventDefault();
       const curr_input = document.getElementById("prompt-input");
+      if (curr_input.value == '') break;
       return completeToken(curr_input.value);
     default:
       break;

--- a/src/commands.js
+++ b/src/commands.js
@@ -48,6 +48,10 @@ function cd(input) {
   position = [];
 }
 
+function openRedirect(input) {
+  return COMMANDS.open.help;
+}
+
 function openLink(input) {
   if (input.length) {
     try {

--- a/src/utils.js
+++ b/src/utils.js
@@ -45,9 +45,16 @@ function pushCommand(cmd) {
 function completeToken(pref) {
   const prompt = document.getElementById("prompt-input");
 
-  // TODO: Autocomplete on commands
-  let commands = pref.split(' ')
-  if (commands.length == 1) {
+  // Autocomplete for commands
+  const cmdParts = pref.split(' ');
+  if (cmdParts.length === 1) {
+    const prefix = cmdParts[0];
+    const matches = Object.keys(COMMANDS).filter(cmd => cmd.startsWith(prefix));
+
+    if (matches.length === 1) {
+      prompt.value = matches[0] + ' ';
+    }
+
     focusPrompt();
     return;
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -58,7 +58,7 @@ function completeToken(pref) {
     focusPrompt();
     return;
   }
-  
+
   // Extract out correct pathPrefix and incomplete pathSuffix
   let pathPrefix = (pref.split(' ')[1] + 'a').split('/');
   let pathSuffix = pathPrefix.pop().slice(0, -1);  // Remove the last character
@@ -87,6 +87,11 @@ function completeToken(pref) {
       focusPrompt();
       return;
     }
+  }
+
+  if (possible == '') {
+    focusPrompt();
+    return;
   }
 
   // Construct final prompt value

--- a/src/utils.js
+++ b/src/utils.js
@@ -47,7 +47,7 @@ function completeToken(pref) {
 
   // Autocomplete for commands
   const cmdParts = pref.split(' ');
-  if (cmdParts.length === 1) {
+  if (!pref.startsWith('./') && cmdParts.length === 1) {
     const prefix = cmdParts[0];
     const matches = Object.keys(COMMANDS).filter(cmd => cmd.startsWith(prefix));
 
@@ -60,7 +60,13 @@ function completeToken(pref) {
   }
 
   // Extract out correct pathPrefix and incomplete pathSuffix
-  let pathPrefix = (pref.split(' ')[1] + 'a').split('/');
+  var pathPrefix;
+  if (pref.startsWith('./')) {
+    pathPrefix = (pref.slice(2) + '_').split('/');
+  } else {
+    pathPrefix = (pref.split(' ')[1] + '_').split('/');
+  }
+
   let pathSuffix = pathPrefix.pop().slice(0, -1);  // Remove the last character
   pathPrefix = pathPrefix.join('/');
 
@@ -95,7 +101,18 @@ function completeToken(pref) {
   }
 
   // Construct final prompt value
-  const result = `${pref.split(' ')[0]} ${pathPrefix}${pathPrefix ? '/' : ''}${possible}`;
+  var result;
+  if (pref.startsWith('./')) {
+    result = "./";
+  } else {
+    result = pref.split(' ')[0] + ' ';
+  }
+  result += pathPrefix;
+  if (pathPrefix) {
+    result += '/'
+  }
+  result += possible;
+
   prompt.value = result;
   focusPrompt();
 }
@@ -164,13 +181,21 @@ function replacePrompt() {
 
 // Parse command input by keeping strings in "" together as an single item
 function parseCommand(input) {
-  const re = /"([^"]+)"|([^\s]+)/g;
+
+  // New open syntax.
   const parsedCmd = [];
+  if (input.startsWith("./")) {
+    parsedCmd.push("./");
+    input = input.slice(2);
+  }
+
+  const re = /"([^"]+)"|([^\s]+)/g;
   let temp;
   while ((temp = re.exec(input)) !== null) {
     const val = temp[1] || temp[2]; // Get the correct capture group
     parsedCmd.push(val);
   }
+  console.log(parsedCmd);
   return parsedCmd;
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -42,6 +42,46 @@ function pushCommand(cmd) {
   focusPrompt();
 }
 
+function completeToken(pref) {
+  const prompt = document.getElementById("prompt-input");
+  
+  // Extract out correct pathPrefix and incomplete pathSuffix
+  let pathPrefix = (pref.split(' ')[1] + 'a').split('/');
+  let pathSuffix = pathPrefix.pop().slice(0, -1);  // Remove the last character
+  pathPrefix = pathPrefix.join('/');
+
+  // Find possible autocomplete targets
+  let targets = list([pathPrefix]);
+  if (!Array.isArray(targets)) {
+    focusPrompt();
+    return;
+  }
+
+  // Initialize possible match variable
+  let possible = '';
+
+  // Iterate over targets to find matching keys
+  for (let i = 0; i < targets.length; i++) {
+    let { key, _ } = targets[i];
+
+    // Have found unique (so far) match
+    if (key.includes(pathSuffix) && !possible) {
+      possible = key;
+    }
+    // Multiple options, pass
+    else if (key.startsWith(pathSuffix)) {
+      focusPrompt();
+      return;
+    }
+  }
+
+  // Construct final prompt value
+  const result = `${pref.split(' ')[0]} ${pathPrefix}${pathPrefix ? '/' : ''}${possible}`;
+  prompt.value = result;
+  focusPrompt();
+}
+
+
 // Returns link url if link or cursor if directory
 // Throw error if bad path
 function locatePath(path) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -44,6 +44,13 @@ function pushCommand(cmd) {
 
 function completeToken(pref) {
   const prompt = document.getElementById("prompt-input");
+
+  // TODO: Autocomplete on commands
+  let commands = pref.split(' ')
+  if (commands.length == 1) {
+    focusPrompt();
+    return;
+  }
   
   // Extract out correct pathPrefix and incomplete pathSuffix
   let pathPrefix = (pref.split(' ')[1] + 'a').split('/');


### PR DESCRIPTION
Implements the tab autocomplete feature for both commands, directories and files.

Behaviour:
- Check if we are doing autocomplete for a command or a file
- If command, we do prefix matching among all commands and return a unique match
- If file, we find the possible file/directories based on given address and current position, then do prefix matching for unique matches

- In all cases, where there is no match, tab does nothing.
- In all cases, where there are multiple valid matches, tab does nothing (no guess).